### PR TITLE
chore(security): redact sensitive auth logs and tighten credential file permissions

### DIFF
--- a/sdk/src/auth/authMiddleware.ts
+++ b/sdk/src/auth/authMiddleware.ts
@@ -19,7 +19,7 @@ const authMiddleware: RequestHandler = safeAsyncHandler(async (req: Request, res
   const credentials = await storage.getCredentialsByClientToken(token);
 
   if (!credentials) {
-    console.info(`[RISEACT-SDK] No credentials found in storage for token ${token}, redirecting to riseact accounts authorize page`);
+    console.info('[RISEACT-SDK] No credentials found in storage for provided client token, redirecting to riseact accounts authorize page');
     // return res.redirect(authorizePageUrl);
     return res.status(401).send('Invalid client token');
   }

--- a/sdk/src/auth/callbackHandler.ts
+++ b/sdk/src/auth/callbackHandler.ts
@@ -46,7 +46,6 @@ const oauthCallbackHandler: RequestHandler = safeAsyncHandler(async (req: Reques
     .catch((e) => {
       console.error('[RISEACT-SDK] Error during OAuth callback with Riseact accounts server. Details below:', e, {
         callbackParams: params,
-        codeVerifier: storedState.codeVerifier,
       });
     });
 
@@ -60,13 +59,12 @@ const oauthCallbackHandler: RequestHandler = safeAsyncHandler(async (req: Reques
 
   if (!refreshToken || !accessToken || !expiresInSeconds) {
     console.error('[RISEACT-SDK] No refresh_token, access_token or expires_in provided from authorization server. Details below:', {
-      refreshToken,
-      accessToken,
+      hasRefreshToken: !!refreshToken,
+      hasAccessToken: !!accessToken,
       expiresInSeconds,
       riseactConfig: config,
       callbackParams: params,
-      codeVerifierCookie: storedState,
-      tokenSet,
+      hasCodeVerifier: !!storedState.codeVerifier,
     });
     return res.sendStatus(500);
   }

--- a/sdk/src/auth/sidExchange.ts
+++ b/sdk/src/auth/sidExchange.ts
@@ -28,7 +28,7 @@ const sidExchangeHandler: RequestHandler = safeAsyncHandler(async (req: Request,
   //   console.error('[RISEACT-SDK] Organization domain mismatch in SID exchange request');
   //   return res.status(400).send('Organization domain mismatch');
   // }
-  console.debug('[RISEACT-SDK] SID exchange successful>', { sid, token });
+  console.debug('[RISEACT-SDK] SID exchange successful>', { sid, organizationDomain: token.organizationDomain });
   return res.json({
     client_token: token.clientToken,
     organization: token.organizationDomain,

--- a/sdk/src/storage/file.ts
+++ b/sdk/src/storage/file.ts
@@ -16,7 +16,7 @@ async function readStore(): Promise<Record<string, StoredOrg>> {
 
 async function writeStore(store: Record<string, StoredOrg>): Promise<void> {
   const tmp = `${CREDENTIALS_FILE}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(store, null, 2), 'utf-8');
+  await fs.writeFile(tmp, JSON.stringify(store, null, 2), { encoding: 'utf-8', mode: 0o600 });
   await fs.rename(tmp, CREDENTIALS_FILE); // atomic swap
 }
 

--- a/sdk/src/utils/lruCache.ts
+++ b/sdk/src/utils/lruCache.ts
@@ -10,7 +10,7 @@ export const pkceStore = new LRUCache<string, PkceRecord>({
 });
 
 export function savePkce(state: string, rec: PkceRecord) {
-  console.info('[RISEACT-SDK] Saving PKCE record', { state, rec });
+  console.info('[RISEACT-SDK] Saving PKCE record', { state, organizationDomain: rec.organizationDomain });
   pkceStore.set(state, rec);
 }
 
@@ -30,7 +30,7 @@ export const sidStore = new LRUCache<string, SidRecord>({
 });
 
 export function saveSid(state: string, rec: SidRecord) {
-  console.info('[RISEACT-SDK] Saving SID record', { state, rec });
+  console.info('[RISEACT-SDK] Saving SID record', { state, organizationDomain: rec.organizationDomain });
   sidStore.set(state, rec);
 }
 


### PR DESCRIPTION
### Motivation
- Reduce the risk of accidental secrets leakage from authentication logs by avoiding printing sensitive values such as PKCE verifiers, SIDs payloads and client tokens.
- Limit filesystem exposure of stored credentials by ensuring temporary credential files are written with restrictive permissions.

### Description
- Replace verbose PKCE/SID payload logging in `savePkce` and `saveSid` with logs that only include non-sensitive metadata (`organizationDomain`) in `sdk/src/utils/lruCache.ts`.
- Remove raw `codeVerifier` and token values from the OAuth callback error log and report presence using booleans (`hasRefreshToken`, `hasAccessToken`, `hasCodeVerifier`) in `sdk/src/auth/callbackHandler.ts`.
- Stop logging full token records during SID exchange and avoid printing the client token in `sdk/src/auth/sidExchange.ts` and make the auth middleware message neutral in `sdk/src/auth/authMiddleware.ts`.
- Harden file-based credential storage by writing the temporary credentials file with restrictive mode `0600` via `fs.writeFile(..., { encoding: 'utf-8', mode: 0o600 })` in `sdk/src/storage/file.ts`.

### Testing
- Ran `npm run lint --workspace sdk`, which failed because the environment is missing the `@typescript-eslint/eslint-plugin` dependency (external to these changes).
- Ran `npm run tsc --workspace sdk`, which failed due to a pre-existing TypeScript error in `sdk/src/startRiseactApp.ts` unrelated to the security edits in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc1a8a85a88325b1e1f70e92a3ca7e)